### PR TITLE
Fix typos in README instructions

### DIFF
--- a/ceptcha/README.txt
+++ b/ceptcha/README.txt
@@ -12,6 +12,6 @@
 
 Look code of the index.php file. There is example how to use ceptcha.
 
-You can change some of the futures of ceptcha image in the method in picture.php file. 
-If you wan't to make biger change go to Captcha.php file or Captcha_Abstract.php
+You can change some of the features of ceptcha image in the method in picture.php file. 
+If you want to make bigger change go to Ceptcha.php file or Captcha_Abstract.php
  


### PR DESCRIPTION
## Summary
- fix README text typos

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68645c3315a48322933ba9bb17f56fad