### PR TITLE
Fix spacing in Ceptcha text rendering

### DIFF
--- a/ceptcha/Ceptcha.php
+++ b/ceptcha/Ceptcha.php
@@ -45,15 +45,15 @@ public function text($font_size) {
     
     $fontColor = imagecolorallocate($this->_image, $red, $green, $blue);
     
-    $finall = $text{$random};
+    $finall = $text[$random];
     
     $niz.=$finall;
     
     $angle = rand(-30,30);//dont exist in abstract class
     
-    $separation = ($this->_width/5)-$font_size;
-    
-    $x = $o*$font_size;
+    $separation = ($this->_width/5) - $font_size;
+
+    $x = $o * $separation;
     
     
     $y = ($this->_height/2);

--- a/ceptcha/Ceptcha_Abstract.php
+++ b/ceptcha/Ceptcha_Abstract.php
@@ -264,7 +264,7 @@ public function text($font_size)
     
    
     
-    $finall = $text{$random};
+    $finall = $text[$random];
     
     $niz.=$finall;
     


### PR DESCRIPTION
## Summary
- fix PHP 7+ compatibility in Ceptcha classes by replacing deprecated string offsets
- use proper character separation in `Ceptcha::text()` so characters are spaced based on image width

## Testing
- `php -l ceptcha/Ceptcha.php` *(fails: php not installed)*
- `php -l ceptcha/Ceptcha_Abstract.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68645b8a7adc832280775219bc53ae2d